### PR TITLE
Adds support for specifying color 0 (Not Applicable) as a part color

### DIFF
--- a/Brickficiency/Classes/DBBLItem.cs
+++ b/Brickficiency/Classes/DBBLItem.cs
@@ -15,5 +15,6 @@ namespace Brickficiency.Classes
         public string dimensions;
         public string catid;
         public Dictionary<string, string> pgpage = new Dictionary<string, string>();
+        public string pgcolourspage;
     }
 }

--- a/Brickficiency/Classes/FinalMatch.cs
+++ b/Brickficiency/Classes/FinalMatch.cs
@@ -48,8 +48,8 @@ namespace Brickficiency.Classes {
             this.xml = "";
         }
 
-        public void AddItem(string id, int qty, decimal price) {
-            itemDictionary.Add(id, new StoreItem(qty, price));
+        public void AddItem(string id, int qty, decimal price, string colour) {
+            itemDictionary.Add(id, new StoreItem(qty, price, colour));
             totalStorePrice += price * qty;
         }
 

--- a/Brickficiency/Classes/Store.cs
+++ b/Brickficiency/Classes/Store.cs
@@ -27,6 +27,11 @@ namespace Brickficiency.Classes {
             return items[id].qty;
         }
 
+        public string getColour(string id)
+        {
+            return items[id].colour;
+        }
+
         public string getName() {
             return name;
         }

--- a/Brickficiency/Classes/StoreItem.cs
+++ b/Brickficiency/Classes/StoreItem.cs
@@ -7,14 +7,17 @@ namespace Brickficiency.Classes {
     public class StoreItem {
         public int qty = 0;
         public decimal price = 64000;
+        public string colour = "0";
 
         public StoreItem() {
             qty = 0;
             price = 64000;
+            colour = "0";
         }
-        public StoreItem(int qty, decimal price) {
+        public StoreItem(int qty, decimal price, string colour) {
             this.price = price;
             this.qty = qty;
+            this.colour = colour;
         }
     }
 }

--- a/Brickficiency/ContextMenuStuff/ColourPicker.cs
+++ b/Brickficiency/ContextMenuStuff/ColourPicker.cs
@@ -22,19 +22,16 @@ namespace Brickficiency.ContextMenuStuff
                 {
                     foreach (DBColour dbcolour in MainWindow.db_colours.Values)
                     {
-                        if (dbcolour.id != "0")
-                        {
-                            Color thiscol = (Color)System.Drawing.ColorTranslator.FromHtml("#" + dbcolour.rgb);
-                            DataGridViewRow dgvrow = new DataGridViewRow();
-                            DataGridViewTextBoxCell dgvcell1 = new DataGridViewTextBoxCell();
-                            dgvcell1.Style.ForeColor = thiscol;
-                            dgvcell1.Style.BackColor = thiscol;
-                            DataGridViewTextBoxCell dgvcell2 = new DataGridViewTextBoxCell();
-                            dgvcell2.Value = dbcolour.name;
-                            dgvrow.Cells.Add(dgvcell1);
-                            dgvrow.Cells.Add(dgvcell2);
-                            dataGridView1.Rows.Add(dgvrow);
-                        }
+                        Color thiscol = (Color)System.Drawing.ColorTranslator.FromHtml("#" + (dbcolour.id != "0" ? dbcolour.rgb : "ffffff"));
+                        DataGridViewRow dgvrow = new DataGridViewRow();
+                        DataGridViewTextBoxCell dgvcell1 = new DataGridViewTextBoxCell();
+                        dgvcell1.Style.ForeColor = thiscol;
+                        dgvcell1.Style.BackColor = thiscol;
+                        DataGridViewTextBoxCell dgvcell2 = new DataGridViewTextBoxCell();
+                        dgvcell2.Value = dbcolour.name;
+                        dgvrow.Cells.Add(dgvcell1);
+                        dgvrow.Cells.Add(dgvcell2);
+                        dataGridView1.Rows.Add(dgvrow);
                     }
                     dataGridView1.Rows[0].Cells[1].Selected = true;
                     dataGridView1.FirstDisplayedScrollingRowIndex = 0;

--- a/Brickficiency/ImportBLWanted.cs
+++ b/Brickficiency/ImportBLWanted.cs
@@ -106,7 +106,7 @@ namespace Brickficiency
             foreach (Item item in tmpwanted)
             {
                 item.status = "I";
-                item.imageurl = "http://www.bricklink.com/getPic.asp?itemType=" + item.type + "&colorID=" + item.colour + "&itemNo=" + item.number;
+                item.imageurl = "http://www.bricklink.com/getPic.asp?itemType=" + item.type + (item.colour == "0" ? "" : "&colorID=" + item.colour) + "&itemNo=" + item.number;
                 item.categoryid = MainWindow.db_blitems[item.id].catid;
                 item.type = MainWindow.db_blitems[item.id].type;
                 try

--- a/Brickficiency/Main.cs
+++ b/Brickficiency/Main.cs
@@ -1860,7 +1860,7 @@ namespace Brickficiency {
         public static string GenerateImageURL(string id, string colour = "large") {
             string imageurl;
             if (colour != "large") {
-                imageurl = "http://www.bricklink.com/getPic.asp?itemType=" + db_blitems[id].type + "&colorID=" + colour + "&itemNo=" + db_blitems[id].number;
+                imageurl = "http://www.bricklink.com/getPic.asp?itemType=" + db_blitems[id].type + (colour == "0" ? "" : "&colorID=" + colour) + "&itemNo=" + db_blitems[id].number;
                 return imageurl;
             } else {
                 imageurl = "http://www.bricklink.com/" + db_blitems[id].type + "L/" + db_blitems[id].number + ".jpg";


### PR DESCRIPTION
Adds support for specifying color 0 (Not Applicable) as a part color, indicating that any color for the part is acceptable. This matches the behavior when specifying color 0 in a BrickLink Wanted List.  This is very useful for getting the best price for builds containing internal or structural elements where the color is not important.

When color 0 is specifed, Brickficiency will first find all available colors for the part and then fetch the price guide information for each color in turn. Each store's lowest price and the corresponding color will
be stored against color 0 in that store's database entry. 

When finding store combinations, the cheapest color for that particular store will be used.
