### PR TITLE
Typo Fix

### DIFF
--- a/Brickficiency/Algorithms.cs
+++ b/Brickficiency/Algorithms.cs
@@ -144,7 +144,7 @@ namespace Brickficiency {
                 // So here we compute the last index of the first (up to) 5 items on the list. The last index of the 5th should be the final index.  
                 // The last index of the rest might be smaller. I haven't figured out exactly how to use this information for items 2-5 yet since
                 // it gets a little more complicated.
-                // CAC, 6/25/15
+                // CAC, 2015-06-25
                 int numToTrack = itemList.Count > 5 ? 5 : itemList.Count;
                 int[] lastnonzeroindex = new int[numToTrack];
                 for (int item = 0; item < numToTrack; item++) {
@@ -160,7 +160,7 @@ namespace Brickficiency {
                 Parallel.For(0, lastnonzeroindex[0] + 1, store1 => {
                     if (calcWorker.CancellationPending || stopAlgorithmEarly) { return; }
                     // Do the next k stores have enough of the first element?  
-                    // If not, none of the rest will so quit. CAC, 6/25/15
+                    // If not, none of the rest will so quit. CAC, 2015-06-25
                     int totalQtyFirst = 0;
                     int lastToCheck = Math.Min(storeList.Count - 1, store1 + k);
                     for (int i = store1; i < lastToCheck; i++) {
@@ -177,7 +177,7 @@ namespace Brickficiency {
                         // possibilities based on lastnonzeroindex[i] for i>0.  Still need to think about this.
                         // I'm leaving it here commented out to remind me that I tried it and realized
                         // that it isn't correct.
-                        // CAC, 7/2/15.
+                        // CAC, 2015-07-02.
                         //end[i] = (i < numToTrack) ? lastnonzeroindex[i] : storeList.Count - k + i;
                     }
                     end[0] = store1;

--- a/Brickficiency/Calculations.cs
+++ b/Brickficiency/Calculations.cs
@@ -40,7 +40,7 @@ namespace Brickficiency {
 
             calcitems = dt2item(dt[currenttab]);
 
-            // Slicker way to remove the unwanted elements.  CAC, 7/1/15
+            // Slicker way to remove the unwanted elements.  CAC, 2015-07-01
             for (int i = calcitems.Count - 1; i >= 0; i--) {
                 Item item = calcitems[i];
                 if ((item.status == "X") || (item.qty == 0)) {
@@ -59,7 +59,7 @@ namespace Brickficiency {
             // This removes from consideration any stores that don't have any of the wanted items
             // since they cannot contribute to a solution.  This can reduce the number of stores
             // that need to be considered significantly.
-            RemoveStoresWitoutAnyWantedItems(); // Added by CAC, 7/1/15
+            RemoveStoresWitoutAnyWantedItems(); // Added by CAC, 2015-07-01
 
             if (calcWorker.CancellationPending) { return; }
 
@@ -240,6 +240,15 @@ namespace Brickficiency {
         {
             if (page == null) return;
 
+#if DEBUG
+            lock(debugparsesource)
+            {
+                StreamWriter swr = new StreamWriter(debugparsesource);
+                swr.Write(page);
+                swr.Close();
+            }
+#endif
+
             List<string> chunks = page.Split(new string[] { "<B>Currently Available</B>" }, StringSplitOptions.None).ToList();
             List<string> rawpgitems;
             if (chunks.Count > 1)
@@ -320,7 +329,7 @@ namespace Brickficiency {
                                 if (StoreDictionary[storename][item.extid].price < price)
                                     StoreDictionary[storename][item.extid].price = price;
                             }
-                            storesWithItemsList.Add(storename); // Added by CAC, 6/24/15
+                            storesWithItemsList.Add(storename); // Added by CAC, 2015-06-24
                         }
                     }
                 }
@@ -349,7 +358,7 @@ namespace Brickficiency {
                 }
             }
             SetProgressBar(calcitems.Count);
-            storesWithItemsList.Clear(); // Added by CAC, 6/24/15
+            storesWithItemsList.Clear(); // Added by CAC, 2015-06-24
 
             foreach (Item item in calcitems) {
                 if (!calcWorker.CancellationPending) {
@@ -375,7 +384,7 @@ namespace Brickficiency {
                             db_blitems[item.id].pgcolourspage = page;
                         }
 
-                        foreach (Match colourmatch in Regex.Matches(page, "http://www\\.bricklink\\.com/catalogPG\\.asp\\?" + item.type + "=" + item.number + "&colorID=([0-9]+)")) {
+                        foreach (Match colourmatch in Regex.Matches(page, "http://www\\.bricklink\\.com/catalogPG\\.asp\\?" + item.type + "=" + item.number + "&ColorID=([0-9]+)")) {
                             string colour = colourmatch.Groups[1].Value;
                             AddStatus(" " + db_colours[colour].name + Environment.NewLine);
                             itemcolours.Add(colour);
@@ -503,7 +512,7 @@ namespace Brickficiency {
                                                 StoreDictionary[storename][item.extid].colour = colour;
                                             }
                                         }
-                                        storesWithItemsList.Add(storename); // Added by CAC, 6/24/15
+                                        storesWithItemsList.Add(storename); // Added by CAC, 2015-06-24
                                     }
                                 }
                             } else {
@@ -754,7 +763,7 @@ namespace Brickficiency {
         }
         #endregion
 
-        // This method was here but isn't used.  I commented it out.  CAC, 7/8/15
+        // This method was here but isn't used.  I commented it out.  CAC, 2015-07-08
         //#region find cheapest from a list
         //private List<int> FindCheapest(params decimal[] pricesin) {
         //    Dictionary<int, decimal> prices = new Dictionary<int, decimal>();
@@ -832,7 +841,7 @@ namespace Brickficiency {
             //shortcount = 0;
             longcount = 0;
 
-            // Added to this method by CAC, 7/6/15 to fix a bug related to the report.
+            // Added to this method by CAC, 2015-07-06 to fix a bug related to the report.
             matches = new List<FinalMatch>();
 
             matchesfoundcount = 0;

--- a/Brickficiency/Classes/Settings.cs
+++ b/Brickficiency/Classes/Settings.cs
@@ -18,6 +18,6 @@ namespace Brickficiency.Classes
         public List<string> countries = new List<string>();
         public string blacklist = "";
 
-        public int approxtime; // added by CAC, 7/8/15
+        public int approxtime; // added by CAC, 2015-07-08
     }
 }

--- a/Brickficiency/Main.cs
+++ b/Brickficiency/Main.cs
@@ -62,6 +62,7 @@ namespace Brickficiency {
         public static string databasezipfilename = programdata + "bfdb.zip";
         public static string databaseurl = "http://www.buildingoutloud.com/bf/bfdb.zip";
         string debugpgfilename = programdata + "\\debug\\Debug-priceguide.txt";
+        string debugparsesource = programdata + "\\debug\\Debug-parsesource.html";
         string debugopenfilename = programdata + "\\debug\\Debug-open.txt";
         string debugdbfilename = programdata + "\\debug\\Debug-db.txt";
         string debugwebreqfilename = programdata + "\\debug\\Debug-webreq.txt";
@@ -118,7 +119,7 @@ namespace Brickficiency {
         public Dictionary<string, bool> blacklistdic = new Dictionary<string, bool>();
 
         //-------------------------------------------------------------------
-        // Fields added or significantly modified by CAC, 6/24/15
+        // Fields added or significantly modified by CAC, 2015-06-24
 
         // Set to true when this is being used for a class and false when it is being released to the public. 
         public Boolean classroomUseMode = false;
@@ -1576,7 +1577,7 @@ dgv[currenttab].Columns["availstores"].ReadOnly = true;
         private void SetProgressBar(int value) {
             this.BeginInvoke(new MethodInvoker(delegate() {
                 progressBar1.Value = 0;
-                progressBar1.Step = 1; // Added by CAC, 6/26/15
+                progressBar1.Step = 1; // Added by CAC, 2015-06-26
                 progressBar1.Maximum = value;
             }));
         }
@@ -1599,7 +1600,7 @@ dgv[currenttab].Columns["availstores"].ReadOnly = true;
         }
         private void Progress() {
             // This is sporadically locking up the GUI.  No idea why.
-            // CAC, 6/24/15.
+            // CAC, 2015-06-24.
             this.BeginInvoke(new MethodInvoker(delegate() {
                 progressBar1.PerformStep();
             }));


### PR DESCRIPTION
There was a RexEx search in 'Calculations.cs' that was searching for
"colorID=..." where the page being searched actually contained
"ColorID=...".

I also added a debug directive to dump the page being parsed for
cost/availability details to 'parsesource.html'.

And finally I changed 'CAC's comments to use international date format
rather than US date format (as in "2015-06-24" as apposed to "6/24/15").
