### PR TITLE
Fixed bugs with 1-store solutions and quantity mul

### DIFF
--- a/Brickficiency/Algorithms.cs
+++ b/Brickficiency/Algorithms.cs
@@ -236,12 +236,13 @@ namespace Brickficiency {
             for (int store1 = 0; store1 < storeList.Count; store1++) {
                 foreach (Item item in itemList) {
                     if (storeList[store1].getQty(item.extid) < item.qty) {
-                        return;
+                        goto nextStore;
                     }
                 }
                 List<string> storeNames = new List<string>();
                 storeNames.Add(storeList[store1].getName());
                 addFinalMatch(storeNames);
+            nextStore:
                 Progress();
             }
         }

--- a/Brickficiency/Main.cs
+++ b/Brickficiency/Main.cs
@@ -2705,7 +2705,7 @@ namespace Brickficiency {
             if (dialogresult == DialogResult.OK) {
                 List<Tuple<string, Del>> valuesList = new List<Tuple<string, Del>>();
                 valuesList.Add(new Tuple<string, Del>("qty", current => (int)current * multiplyItemsWindow.num));
-                valuesList.Add(new Tuple<string, Del>("total", current => (double)current * multiplyItemsWindow.num));
+                valuesList.Add(new Tuple<string, Del>("total", current => (decimal)current * multiplyItemsWindow.num));
 
                 SortSafeSet(valuesList);
             }
@@ -2718,7 +2718,7 @@ namespace Brickficiency {
             if (dialogresult == DialogResult.OK) {
                 List<Tuple<string, Del>> valuesList = new List<Tuple<string, Del>>();
                 valuesList.Add(new Tuple<string, Del>("qty", current => (int)current / multiplyItemsWindow.num));
-                valuesList.Add(new Tuple<string, Del>("total", current => (double)current / multiplyItemsWindow.num));
+                valuesList.Add(new Tuple<string, Del>("total", current => (decimal)current / multiplyItemsWindow.num));
 
                 SortSafeSet(valuesList);
             }


### PR DESCRIPTION
When considering 1-store solutions it would stop at the first store that
didn't have sufficient stock to match the order, and subsequent stores
were skipped.

Fixed a crash changing quantity by a multiplier.
